### PR TITLE
Set module to es2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
+    "module": "es2020",
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Module was previously set to 'es2015' as the default when 'target' is 'es2020'. Now it is set to 'es2020' to support feature like dynamic imports